### PR TITLE
added font smoothing for higher resolution displays

### DIFF
--- a/xp.css
+++ b/xp.css
@@ -6,7 +6,7 @@ body {
   background-attachment: fixed;
   padding-top: 60px;
   padding-bottom: 80px;
-  -webkit-font-smoothing: none;
+  -webkit-font-smoothing: auto;
 }
 
 /* Header */


### PR DESCRIPTION
On a 4k display the font displayed is barely legible. setting -webkit-font-smoothing to auto seems to help. 