### PR TITLE
Remove font-smoothing override

### DIFF
--- a/xp.css
+++ b/xp.css
@@ -6,7 +6,6 @@ body {
   background-attachment: fixed;
   padding-top: 60px;
   padding-bottom: 80px;
-  -webkit-font-smoothing: none;
 }
 
 /* Header */


### PR DESCRIPTION
Fonts looks really bad on Mac Chrome 67 without antialiasing.

**Before:**
![image](https://user-images.githubusercontent.com/2797532/41058181-bc14bede-698e-11e8-9c52-0716dccd613a.png)
**After:**
![image](https://user-images.githubusercontent.com/2797532/41058202-cbe1d4aa-698e-11e8-91cf-11dd1177a0fc.png)
