### PR TITLE
Fix Clippy balloon z-index

### DIFF
--- a/xp.css
+++ b/xp.css
@@ -317,6 +317,7 @@ title:before {
   font-weight: normal;
   cursor: default;
   pointer-events: none;
+  z-index: 100;
 }
 
 .js-issue-row:first-child:before,


### PR DESCRIPTION
In some resolutions, Clippy's helpful commentaries would be placed behind some UI elements, like:
![image](https://user-images.githubusercontent.com/6223070/41062401-186da8f4-69ac-11e8-80ac-c2b768d8474f.png)

This PR fixes this issue by applying some `z-index` on the message element. The result will be:
![image](https://user-images.githubusercontent.com/6223070/41062562-93d77628-69ac-11e8-83de-deb6b7a3e508.png)