### PR TITLE
anti-aliasing for fonts

### DIFF
--- a/xp.css
+++ b/xp.css
@@ -22,6 +22,9 @@ body:not([class]) strong {
   font-size: 16px;
   line-height: 1.2;
   text-align: left;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
 }
 body:not([class]) .container::before,
 body:not([class]) .container::after {


### PR DESCRIPTION
text is difficult to read on mac chrome. Adding anti aliasing to make text easier to read.

without anti aliasing:
![screen shot 2018-06-07 at 3 19 20 pm](https://user-images.githubusercontent.com/857063/41129375-99e4c006-6a66-11e8-92d7-0750b51f3c90.png)

with anti aliasing:
![screen shot 2018-06-07 at 3 19 27 pm](https://user-images.githubusercontent.com/857063/41129387-a7838904-6a66-11e8-9bc2-9833e2952eb0.png)
