### PR TITLE
Fix search bar color when clicking on it

### DIFF
--- a/xp.css
+++ b/xp.css
@@ -130,6 +130,13 @@ body:not([class]) .container::after {
     inset 0 -1px rgba(255, 255, 255, 0.1) !important;
 }
 
+.Header .header-search-wrapper .jump-to-field-active {
+  color: inherit !important;
+  background-color: rgba(255, 255, 255, 0.025);
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
+
 .jump-to-suggestions {
   top: auto !important;
   bottom: 35px;


### PR DESCRIPTION
The search bar would always turn white and lose rounding at the bottom when focused. This pull request fixes that.

Before:
![image](https://user-images.githubusercontent.com/1517255/41171462-f342077c-6b50-11e8-8f12-625230b81272.png)

After:
![image](https://user-images.githubusercontent.com/1517255/41171490-116b4ab0-6b51-11e8-906a-b52ef96cbfa0.png)