### PR TITLE
Fix CSS to work with Github changes (2019)

### DIFF
--- a/xp.css
+++ b/xp.css
@@ -139,7 +139,7 @@ body:not([class]) .container::after {
 }
 
 /* Wrapper element (main "window") */
-[role="main"] {
+.application-main {
   position: relative;
   box-sizing: initial;
   background: white;
@@ -154,14 +154,14 @@ body:not([class]) .container::after {
   box-shadow: 0 0 0 2px #2b6dd1;
 }
 
-[role="main"]:after {
+.application-main:after {
   content: "";
   display: block;
   clear: both;
 }
 
 /* Window top bar */
-[role="main"]:before {
+.application-main:before {
   content: "";
   display: block;
   position: absolute;
@@ -183,7 +183,7 @@ body:not([class]) .container::after {
   box-shadow: inset 0 0 2px 1px rgba(0, 0, 0, 0.2);
 }
 
-[role="main"]:after {
+.application-main:after {
   content: "";
   display: block;
   position: absolute;

--- a/xp.css
+++ b/xp.css
@@ -46,8 +46,8 @@ body:not([class]) .container::after {
 }
 
 /* Header */
-.Header,
-.Header.position-relative {
+header,
+header.position-relative {
   position: fixed !important;
   left: 0;
   bottom: 0;
@@ -67,7 +67,7 @@ body:not([class]) .container::after {
   z-index: 100 !important;
 }
 
-.Header .d-flex {
+header .d-flex {
   max-width: 100% !important;
 }
 
@@ -109,23 +109,23 @@ body:not([class]) .container::after {
 }
 
 /* Make header tooltips/menus yellow. Fix positioning */
-.Header .dropdown .dropdown-menu,
-.Header .tooltipped-s::after,
-.Header .tooltipped-se::after,
-.Header .tooltipped-sw::after {
+header .dropdown .dropdown-menu,
+header .tooltipped-s::after,
+header .tooltipped-se::after,
+header .tooltipped-sw::after {
   top: auto;
   bottom: 100%;
   background: #ffffe1;
   color: black;
 }
 
-.Header .dropdown .dropdown-menu:after,
-.Header .tooltipped:before,
+header .dropdown .dropdown-menu:after,
+header .tooltipped:before,
 .header-search-key-slash {
   display: none;
 }
 
-.Header .header-search-wrapper {
+header .header-search-wrapper {
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.5),
     inset 0 -1px rgba(255, 255, 255, 0.1) !important;
 }

--- a/xp.css
+++ b/xp.css
@@ -109,7 +109,7 @@ header .d-flex {
 }
 
 /* Make header tooltips/menus yellow. Fix positioning */
-header .dropdown .dropdown-menu,
+header .dropdown-menu,
 header .tooltipped-s::after,
 header .tooltipped-se::after,
 header .tooltipped-sw::after {
@@ -119,7 +119,8 @@ header .tooltipped-sw::after {
   color: black;
 }
 
-header .dropdown .dropdown-menu:after,
+header .dropdown-menu:before,
+header .dropdown-menu:after,
 header .tooltipped:before,
 .header-search-key-slash {
   display: none;


### PR DESCRIPTION
Tested on Chrome and Firefox, with Stylus extension.

I am still unable to trigger Clippy `.repository-meta-content:after` and `.js-user-profile-bio-contents:after`. Maybe Github removed those classes.